### PR TITLE
Support for memory-deduplication

### DIFF
--- a/experiments/memdup/.gitignore
+++ b/experiments/memdup/.gitignore
@@ -1,0 +1,2 @@
+images
+counter

--- a/experiments/memdup/benchmark_memdup.md
+++ b/experiments/memdup/benchmark_memdup.md
@@ -1,0 +1,58 @@
+## runc-iterative
+
++ Experiment:
+    1. Run container
+    2. Run the binaries: `pre-dump.sh` `middle-dump.sh`, and `dump.sh` sequentially.
+    3. Report the size of `pages.img` file.
+
+1. Runc w/ pre-dump and auto-dedup (disk | tmpfs):
+    + Dir 1: 11 M | 
+    + Dir 2: 6.1 M
+    + Dir 3: 6.1 M
+    + Ratio: 55%
+
+2. Runc w/ pre-dump w/out auto-dedup:
+    + Dir 1: 8.4 M
+    + Dir 2: 4.1 M
+    + Dir 3: 4.1 M
+    + Ratio: 48%
+
+3. Runc w/ pre-dump w/ page-server w/out auto-dedup (disk | tmpfs):
+    + Dir 1: 8.4M  
+    + Dir 2: 4.1M
+    + Dir 3: 4.1M
+    + Ratio: 48%
+
+4. Runc w/ pre-dump w/ page-server w/ auto-dedup and tmpfs:
+    + Dir 1: 8.4M
+    + Dir 2: 4.1M
+    + Dir 3: 4.1M
+    + Ratio: 48%
+
++ Open questions:
+    + Why does `auto-dedup` flag add more to the base image (and less compression)?
+        - It seems it only works in the "diskless" setting where images are stored in RAM (makes sense).
+          See here: https://criu.org/Memory_images_deduplication.
+        - Even in the diskless setting, via runc it does nothing.
+
+==============================================================================
+
+## iterative-migration w/ criu
+
++ All experiments w/ tmpfs
++ The experiment literally does nothing (it sleeps), I wonder what does 12K are, see Observations.
+
+1. Criu w/ pre-dump w/out auto-dedup:
+    + Dir 1: 92K
+    + Dir 2: 12K
+    + Dir 3: 12K
+    + Ratio: 13%
+
+2. Criu w/ pre-dump w/ auto-dedup:
+    + Dir 1: 92K
+    + Dir 2: 12K
+    + Dir 3: 12K
+    + Ratio: 13%
+
++ Observations:
+    + Every time you do a pre-dump or a dump, the process is frozen and if it was in the middle of, for instance, a sleep, it will resume outside of the sleep.

--- a/experiments/memdup/iterative-migration/Makefile
+++ b/experiments/memdup/iterative-migration/Makefile
@@ -1,0 +1,8 @@
+CC = gcc
+OBJ = counter
+
+counter: counter.c
+	${CC} counter.c -o ${OBJ}
+
+clean:
+	rm ${OBJ}

--- a/experiments/memdup/iterative-migration/clean.sh
+++ b/experiments/memdup/iterative-migration/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo rm ./images/1/*
+sudo rm ./images/2/*
+sudo rm ./images/3/*

--- a/experiments/memdup/iterative-migration/counter.c
+++ b/experiments/memdup/iterative-migration/counter.c
@@ -1,0 +1,24 @@
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static volatile int keep_running = 1;
+
+void int_handler(int tmp)
+{
+    keep_running = 0;
+}
+
+int main()
+{
+    int count = 0;
+    signal(SIGINT, int_handler);
+
+    fprintf(stdout, "Current count: %i\n", count++);
+    while (keep_running)
+    {
+        sleep(20);
+    }
+
+    return 0;
+}

--- a/experiments/memdup/iterative-migration/dump.sh
+++ b/experiments/memdup/iterative-migration/dump.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Experiment 1
+#sudo criu dump \
+#    -t  `pidof counter` \
+#    --images-dir images/3 \
+#    --prev-images-dir ../2 \
+#    --shell-job \
+#    --track-mem
+
+#Experiment 2
+sudo criu dump \
+    -t  `pidof counter` \
+    --images-dir images/3 \
+    --prev-images-dir ../2 \
+    --shell-job \
+    --track-mem \
+    --auto-dedup
+
+# Experiment 3
+#sudo criu dump \
+#    -t  `pidof counter` \
+#    --images-dir images/3 \
+#    --prev-images-dir ../2 \
+#    --shell-job \
+#    --track-mem \
+#    --page-server \
+#    --address 127.0.0.1 \
+#    --port 9999

--- a/experiments/memdup/iterative-migration/middle-dump.sh
+++ b/experiments/memdup/iterative-migration/middle-dump.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Experiment 1
+#sudo criu pre-dump \
+#    -t  `pidof counter` \
+#    --shell-job \
+#    --images-dir images/2 \
+#    --prev-images-dir ../1 \
+
+# Experiment 2
+sudo criu pre-dump \
+    -t  `pidof counter` \
+    --shell-job \
+    --images-dir images/2 \
+    --prev-images-dir ../1 \
+    --auto-dedup
+
+# Experiment 3
+#sudo criu pre-dump \
+#    -t  `pidof counter` \
+#    --images-dir images/2 \
+#    --shell-job \
+#    --prev-images-dir ../1 \
+#    --page-server \
+#    --track-mem \
+#    --address 127.0.0.1 \
+#    --port 9999

--- a/experiments/memdup/iterative-migration/page-server.sh
+++ b/experiments/memdup/iterative-migration/page-server.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo criu page-server --port 9999 --images-dir ./images/$1/

--- a/experiments/memdup/iterative-migration/pre-dump.sh
+++ b/experiments/memdup/iterative-migration/pre-dump.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Experiment 1
+#sudo criu pre-dump \
+#    -t  `pidof counter` \
+#    --images-dir images/1 \
+#    --shell-job \
+
+# Experiment 2
+sudo criu pre-dump \
+    -t  `pidof counter` \
+    --images-dir images/1 \
+    --shell-job \
+    --auto-dedup
+
+# Experiment 3
+#sudo criu pre-dump \
+#    -t  `pidof counter` \
+#    --images-dir images/1 \
+#    --shell-job \
+#    --page-server \
+#    --address 127.0.0.1 \
+#    --port 9999

--- a/experiments/memdup/runc-iterative/clean.sh
+++ b/experiments/memdup/runc-iterative/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo rm ./images/1/*
+sudo rm ./images/2/*
+sudo rm ./images/3/*

--- a/experiments/memdup/runc-iterative/dump.sh
+++ b/experiments/memdup/runc-iterative/dump.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Experiment 1
+#sudo runc checkpoint \
+#    --parent-path ../2/ \
+#    --auto-dedup \
+#    --image-path ./images/3/ \
+#    eureka
+
+# Experiment 2
+#sudo runc checkpoint \
+#    --parent-path ../2/ \
+#    --image-path ./images/3/ \
+#    eureka
+
+# Experiment 3
+#sudo runc checkpoint \
+#    --page-server 127.0.0.1:9999 \
+#    --parent-path ../2/ \
+#    --image-path ./images/3/ \
+#    eureka
+
+# Experiment 4
+#sudo runc checkpoint \
+#    --page-server 127.0.0.1:9999 \
+#    --auto-dedup \
+#    --parent-path ../2/ \
+#    --image-path ./images/3/ \
+#    eureka
+
+# Experiment 5
+sudo runc checkpoint \
+    --page-server 192.168.56.103:9999 \
+    --parent-path ../2/ \
+    --image-path ./images/3/ \
+    eureka

--- a/experiments/memdup/runc-iterative/middle-dump.sh
+++ b/experiments/memdup/runc-iterative/middle-dump.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Experiment 1
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --auto-dedup \
+#    --parent-path ../1/ \
+#    --image-path ./images/2/ \
+#    eureka
+
+# Experiment 2
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --parent-path ../1/ \
+#    --image-path ./images/2/ \
+#    eureka
+
+# Experiment 3
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --page-server 127.0.0.1:9999 \
+#    --parent-path ../1/ \
+#    --image-path ./images/2/ \
+#    eureka
+
+# Experiment 4
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --auto-dedup \
+#    --page-server 127.0.0.1:9999 \
+#    --parent-path ../1/ \
+#    --image-path ./images/2/ \
+#    eureka
+
+# Experiment 5
+sudo runc checkpoint \
+    --pre-dump \
+    --page-server 192.168.56.103:9999 \
+    --parent-path ../1/ \
+    --image-path ./images/2/ \
+    eureka

--- a/experiments/memdup/runc-iterative/page-server.sh
+++ b/experiments/memdup/runc-iterative/page-server.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo criu page-server --port 9999 --images-dir ./images/$1/
+#sudo criu page-server --auto-dedup --port 9999 --images-dir ./images/$1/

--- a/experiments/memdup/runc-iterative/pre-dump.sh
+++ b/experiments/memdup/runc-iterative/pre-dump.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Experiment 1
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --auto-dedup \
+#    --image-path ./images/1/ \
+#    eureka
+
+# Experiment 2
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --image-path ./images/1/ \
+#    eureka
+
+# Experiment 3
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --page-server 127.0.0.1:9999 \
+#    --image-path ./images/1/ \
+#    eureka
+
+# Experiment 4
+#sudo runc checkpoint \
+#    --pre-dump \
+#    --auto-dedup \
+#    --page-server 127.0.0.1:9999 \
+#    --image-path ./images/1/ \
+#    eureka
+
+# Experiment 5
+sudo runc checkpoint \
+    --pre-dump \
+    --page-server 192.168.56.103:9999 \
+    --image-path ./images/1/ \
+    eureka

--- a/migration/src/migration.c
+++ b/migration/src/migration.c
@@ -16,6 +16,8 @@ struct migration_args {
     int iterative;
     char *src_image_path;
     char *dst_image_path;
+    char *src_prev_image_dir;
+    char *dst_prev_image_dir;
     char *dst_host;
     char *dst_user;
     char *page_server_host;
@@ -205,6 +207,10 @@ static int init_migration(struct migration_args *args)
     memset(args->dst_image_path, '\0', MAX_CMD_SIZE);
     strcpy(args->src_image_path, "/dev/shm/criu-src-dir");
     strcpy(args->dst_image_path, "/dev/shm/criu-dst-dir");
+    args->src_prev_image_dir = (char *) malloc(MAX_CMD_SIZE * sizeof(char));
+    memset(args->src_prev_image_dir, '\0', MAX_CMD_SIZE);
+    args->dst_prev_image_dir = (char *) malloc(MAX_CMD_SIZE * sizeof(char));
+    memset(args->dst_prev_image_dir, '\0', MAX_CMD_SIZE);
     args->session = ssh_start(args->dst_host, args->dst_user);
     return 0;
 }
@@ -215,7 +221,7 @@ static int init_migration(struct migration_args *args)
  * Recall that the page-server is a one-shot command, and need to be re
  * run everytime if we are doing a diskless migration.
  */
-static int prepare_migration(struct migration_args *args)
+static int prepare_migration(struct migration_args *args, int first_iter)
 {
     int rc;
     /* Make local dir for checkpoint files */
@@ -235,8 +241,20 @@ static int prepare_migration(struct migration_args *args)
         return 1;
     }
     memset(rm_cmd, '\0', MAX_CMD_SIZE);
-    sprintf(rm_cmd, "echo %s | sudo -S criu page-server -d --images-dir %s --port %s",
-            REMOTE_PWRD, args->dst_image_path, args->page_server_port);
+    if (first_iter)
+    {
+        sprintf(rm_cmd, "echo %s | sudo -S criu page-server -d --images-dir %s --port %s",
+                REMOTE_PWRD, args->dst_image_path, args->page_server_port);
+    }
+    else
+    {
+        sprintf(rm_cmd, "echo %s | sudo -S criu page-server -d "
+                        "--images-dir %s "
+                        "--prev-images-dir %s "
+                        "--port %s",
+                REMOTE_PWRD, args->dst_image_path, args->dst_prev_image_dir,
+                args->page_server_port);
+    }
     if (ssh_remote_command(args->session, rm_cmd, 0) != SSH_OK)
     {
         fprintf(stderr, "prepare_migration: error initializing remote page server.\n");
@@ -315,7 +333,6 @@ static int iterative_migration(struct migration_args *args)
     #endif
     
     /* Initialize the Recurrent Command we will Issue */
-    char old_src_path[MAX_CMD_SIZE];
     char old_dst_path[MAX_CMD_SIZE];
     char cmd_db[MAX_CMD_SIZE];
     char cmd_dump[MAX_CMD_SIZE];
@@ -343,8 +360,10 @@ static int iterative_migration(struct migration_args *args)
     /* --track-mem is turned on by default if --parent-path is provided
      * see: runc/libcontainer/container_linux.go#L1032
      */
-    char *fmt_cmd_dump = "sudo runc checkpoint --pre-dump --image-path %s \
-                          --parent-path %s --page-server %s:%s %s";
+    char *fmt_cmd_dump = "sudo runc checkpoint --pre-dump "
+                         "--image-path %s "
+                         "--parent-path %s "
+                         "--page-server %s:%s %s";
     char *fmt_cmd_symlink = "ln -s %s %s/parent";
 
     /* Start Iterative Page Dump 
@@ -362,7 +381,7 @@ static int iterative_migration(struct migration_args *args)
             gettimeofday(&t_ini, NULL);
         #endif
         printf("LOG: Iterative Migration --> Step %i.\n", i);
-        if (prepare_migration(args) != 0)
+        if (prepare_migration(args, i == 0) != 0)
         {
             fprintf(stderr, "iterative_migration: prepare migration failed at \
                              iteration %i.\n", i + 1);
@@ -374,8 +393,9 @@ static int iterative_migration(struct migration_args *args)
                     --page-server %s:%s %s", args->src_image_path, 
                     args->dst_host, args->page_server_port, args->name);
         else
-            sprintf(cmd_dump, fmt_cmd_dump, args->src_image_path, old_src_path,
-                    args->dst_host, args->page_server_port, args->name);
+            sprintf(cmd_dump, fmt_cmd_dump, args->src_image_path,
+                    args->src_prev_image_dir, args->dst_host,
+                    args->page_server_port, args->name);
         fprintf(stdout, "DEBUG: dump command '%s'\n", cmd_dump);
         /* Finish Prepare Migration */
         #if BENCHMARK
@@ -404,7 +424,7 @@ static int iterative_migration(struct migration_args *args)
             gettimeofday(&t_ini, NULL);
         #endif
         if (sftp_copy_dir(args->session, args->dst_image_path, 
-                          args->src_image_path, 1, &dir_size) != SSH_OK)
+                          args->src_image_path, 0, &dir_size) != SSH_OK)
         {
             fprintf(stderr, "migration: error transferring from '%s' to '%s'\n",
                     args->src_image_path, args->dst_image_path);
@@ -425,6 +445,7 @@ static int iterative_migration(struct migration_args *args)
         #if BENCHMARK 
             gettimeofday(&t_ini, NULL);
         #endif
+        /* TODO remove
         if (i > 0)
         {
             memset(cmd_symlink, '\0', MAX_CMD_SIZE);
@@ -437,11 +458,22 @@ static int iterative_migration(struct migration_args *args)
                 return 1;
             }
         }
+        */
         /* Swap Dirs */
-        memset(old_src_path, '\0', MAX_CMD_SIZE);
-        strcpy(old_src_path, args->src_image_path);
-        memset(old_dst_path, '\0', MAX_CMD_SIZE);
-        strcpy(old_dst_path, args->dst_image_path);
+        const char s[4] = "/";
+        char *tok;
+        char tmp[100];
+        strcpy(tmp, args->dst_image_path);
+        tok = strtok(tmp, s);
+        tok = strtok(0, s);
+        tok = strtok(0, s);
+        sprintf(args->dst_prev_image_dir, "../%s", tok);
+        memset(tmp, '\0', 100);
+        strcpy(tmp, args->src_image_path);
+        tok = strtok(tmp, s);
+        tok = strtok(0, s);
+        tok = strtok(0, s);
+        sprintf(args->src_prev_image_dir, "../%s", tok);
         iterative_migration_inc_dirs(args, i);
         #if BENCHMARK
             gettimeofday(&t_end, NULL);
@@ -511,7 +543,7 @@ int migration(struct migration_args *args)
     #if BENCHMARK
         gettimeofday(&t_ini, NULL);
     #endif
-    if (prepare_migration(args) != 0)
+    if (prepare_migration(args, 0) != 0)
     {
         fprintf(stderr, "migration: prepare_migration failed.\n");
         if (clean_env(args) != 0)
@@ -526,8 +558,10 @@ int migration(struct migration_args *args)
     char cmd_rs[MAX_CMD_SIZE];
     memset(cmd_cp, '\0', MAX_CMD_SIZE);
     memset(cmd_rs, '\0', MAX_CMD_SIZE);
-    char *fmt_cp = "sudo runc checkpoint --image-path %s --page-server \
-                    %s:%s %s";
+    char *fmt_cp = "sudo runc checkpoint "
+                   "--parent-path ../criu-src-dir-4 "
+                   "--image-path %s "
+                   "--page-server %s:%s %s";
     char *fmt_rs = "cd %s && echo %s | sudo -S runc restore --image-path %s \
                     %s-restored &> /dev/null < /dev/null &";
     sprintf(cmd_cp, fmt_cp, args->src_image_path, args->dst_host,
@@ -560,10 +594,10 @@ int migration(struct migration_args *args)
         times[1] = timeval_to_milis(&t_result);
     #endif
 
-    /* Copy the Remaining Files (should be few as we are running diskless */
+    /* Copy the Remaining Files (should be few as we are running diskless) */
     gettimeofday(&t_ini, NULL);
     if (sftp_copy_dir(args->session, args->dst_image_path, 
-                      args->src_image_path, 1, &dir_size) != SSH_OK)
+                      args->src_image_path, 0, &dir_size) != SSH_OK)
     {
         fprintf(stderr, "migration: error transferring from '%s' to '%s'\n",
                 args->src_image_path, args->dst_image_path);
@@ -579,6 +613,17 @@ int migration(struct migration_args *args)
         timersub(&t_end, &t_ini, &t_result);
         times[2] = timeval_to_milis(&t_result);
     #endif
+
+    /* Add the symlink to the parent dir */
+    /* TODO Remove
+    char *cmd_symlink = "ln -s /dev/shm/criu-dst-dir-4 /dev/shm/criu-dst-dir-5/parent";
+    if (ssh_remote_command(args->session, cmd_symlink, 0) != SSH_OK)
+    {
+        fprintf(stderr, "migration: error creating symlink \
+                         w/ command: '%s'\n", cmd_symlink);
+        return 1;
+    }
+    */
 
     /* Restore the Running Container */
     #if BENCHMARK

--- a/migration/src/migration.c
+++ b/migration/src/migration.c
@@ -235,7 +235,7 @@ static int prepare_migration(struct migration_args *args)
         return 1;
     }
     memset(rm_cmd, '\0', MAX_CMD_SIZE);
-    sprintf(rm_cmd, "echo %s | sudo -S criu page-server -d --auto-dedup --images-dir %s --port %s",
+    sprintf(rm_cmd, "echo %s | sudo -S criu page-server -d --images-dir %s --port %s",
             REMOTE_PWRD, args->dst_image_path, args->page_server_port);
     if (ssh_remote_command(args->session, rm_cmd, 0) != SSH_OK)
     {
@@ -340,8 +340,11 @@ static int iterative_migration(struct migration_args *args)
     //int db_pattern[7] = {1000, 1000, 1000, 1000, 1000, 1000}; // Pattern 1
     int db_pattern[6] = {1000, 500, 250, 125, 75, 25}; // Pattern 2
     //int db_pattern[6] = {1000, 1000, 1000, 1000, 1000, 1000}; // Pattern 1
+    /* --track-mem is turned on by default if --parent-path is provided
+     * see: runc/libcontainer/container_linux.go#L1032
+     */
     char *fmt_cmd_dump = "sudo runc checkpoint --pre-dump --image-path %s \
-                          --auto-dedup --parent-path %s --page-server %s:%s %s";
+                          --parent-path %s --page-server %s:%s %s";
     char *fmt_cmd_symlink = "ln -s %s %s/parent";
 
     /* Start Iterative Page Dump 
@@ -368,7 +371,7 @@ static int iterative_migration(struct migration_args *args)
         memset(cmd_dump, '\0', MAX_CMD_SIZE);
         if (i == 0)
             sprintf(cmd_dump, "sudo runc checkpoint --pre-dump --image-path %s \
-                    --auto-dedup --page-server %s:%s %s", args->src_image_path, 
+                    --page-server %s:%s %s", args->src_image_path, 
                     args->dst_host, args->page_server_port, args->name);
         else
             sprintf(cmd_dump, fmt_cmd_dump, args->src_image_path, old_src_path,

--- a/migration/src/net_utils.c
+++ b/migration/src/net_utils.c
@@ -390,7 +390,7 @@ int sftp_copy_dir(ssh_session session, char *dst_path, char *src_path,
                     sftp_free(sftp);
                     return SSH_ERROR;
                 }
-                if (remove(resolved_path) != 0)
+                if (rm_ori && remove(resolved_path) != 0)
                 {
                     fprintf(stderr, "sftp_copy_dir: error removing local \
                                      file %s (remove flag set)\n",


### PR DESCRIPTION
Memory deduplication was not working given that the `page-server` was not set up properly. However, performance is still rather poor in `runc` when copared to baseline `criu`.

In the latter, recurrent dumps of the same address space only reduce the original image size to a 48%, wheras criu gets to a 12% (numbers are preliminary as they are done on different binaries).